### PR TITLE
Fix tests

### DIFF
--- a/app/models/package.scala
+++ b/app/models/package.scala
@@ -5,7 +5,7 @@ package object models {
   import play.api.Logger
   import play.api.Play.current
 
-  lazy val db = {
+  def db = {
     Logger.debug(s"Configuring slick database: $DB")
     Database.forDataSource(DB.getDataSource())
   }

--- a/test/ApplicationSpec.scala
+++ b/test/ApplicationSpec.scala
@@ -24,7 +24,7 @@ class ApplicationSpec extends Specification {
 
       status(home) must equalTo(OK)
       contentType(home) must beSome.which(_ == "text/html")
-      contentAsString(home) must contain ("Your new application is ready.")
+      contentAsString(home) must contain ("151 Challenge")
     }
   }
 }

--- a/test/IntegrationSpec.scala
+++ b/test/IntegrationSpec.scala
@@ -18,7 +18,7 @@ class IntegrationSpec extends Specification {
 
       browser.goTo("http://localhost:" + port)
 
-      browser.pageSource must contain("Your new application is ready.")
+      browser.pageSource must contain("151 Challenge")
     }
   }
 }


### PR DESCRIPTION
I hate working without tests, so this makes `./activator ~test` pass. But since I'm not too familiar w/this environment, it seems to me that there might be a better way of doing this than `s/lazy val/def` for the database connection.
